### PR TITLE
Fix hooks documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ const Page = () => {
     });
 
     return (
-        <animated.div ref={ref} style={animation}>
-            Hello World!
-        </animated.div>
+        <div ref={ref}>
+            <animated.h1 style={animation}>Hello World!</animated.h1>
+        </div>
     );
 };
 ```
+
+**_WARNING! It is VERY important that you do not put the ref directly on an animated tag or multiple hooks will NOT WORK!_**
 
 ### Render Props API
 
@@ -101,6 +103,8 @@ const Page = () => {
 ```
 
 ## API
+
+**_WARNING! It is VERY important that you do not put the ref directly on an animated tag or multiple hooks will NOT WORK!_**
 
 _This table applies to both the Hooks API and the Render Props API._
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
     "name": "@play-when-visible/react-spring",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "repository": "https://github.com/play-when-visible/react-spring.git",
     "author": "Im-Stevemmmmm <estebangarcia2121@gmail.com>",
     "license": "MIT",
     "keywords": [
-        "react spring", "react"
+        "react spring",
+        "react"
     ],
     "scripts": {
         "build": "rollup --config",


### PR DESCRIPTION
- v1.0.1
- Added proper hook example and warning

Added a proper hook example and a warning to never put the ref directly on an animated tag or the animations will not work.

Closes #1 